### PR TITLE
Use the static-build of raylib?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(CMAKE_BUILD_TYPE "Release")
 FetchContent_Declare(raylib GIT_REPOSITORY https://github.com/raysan5/raylib.git GIT_TAG 4.5.0)
 FetchContent_MakeAvailable(raylib)
 
-add_library(${PROJECT_NAME} SHARED src/lib.c)
+add_library(${PROJECT_NAME} STATIC src/lib.c)
 target_link_libraries(${PROJECT_NAME} PRIVATE raylib)
 
 add_executable(${PROJECT_NAME}_test src/lib.c src/test.c)


### PR DESCRIPTION
This change makes the native build of this compile raylib static, meaning raylib would be embedded in the application, and not have to be loaded through an external shared DLL.