### PR TITLE
Add UnloadGame()

### DIFF
--- a/src/test.c
+++ b/src/test.c
@@ -26,12 +26,20 @@ void UpdateGame() {
   rp_EndDrawing();
 }
 
+void UnloadGame() {
+  // Unload the texture, and free the object
+  rp_UnloadTexture(texBunny);
+  free((void*)texBunny);
+
+  rp_CloseWindow();
+}
+
 int main(void) {
   InitGame();
   rp_SetTargetFPS(60);
   while (!rp_WindowShouldClose()) {
     UpdateGame();
   }
-  rp_CloseWindow();
+  UnloadGame();
   return 0;
 }


### PR DESCRIPTION
Since `rp_UnloadTexture()` doesn't actually free the object, we need to manually call `free()` on it. Would be cool if we called `free()` on it within the `rp_UnloadTexture()` function itself :wink: 